### PR TITLE
fix generation of random file names

### DIFF
--- a/lib/File/Temp.pm
+++ b/lib/File/Temp.pm
@@ -1,11 +1,11 @@
-module File::Temp:ver<0.01>;
+module File::Temp:ver<0.02>;
 
 # Characters used to create temporary file/directory names
-constant FILECHARS = 'a'..'z', 'A'..'Z', 0..9, '_';
+my @filechars = 'a'..'z', 'A'..'Z', 0..9, '_';
 constant MAX-RETRIES = 10;
 
 sub gen-random($n) {
-    return join '', map { FILECHARS[Int(rand * +FILECHARS)] }, ^$n;
+    @filechars.roll($n).join
 }
 
 my @open-files;


### PR DESCRIPTION
used to choose one of the ranges at random and join all the characters
in the range together, leading to temp file names like __abcdefghijklmnopqrst
uvwxyz___ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
