### PR TITLE
Add unit declarator to module declaration

### DIFF
--- a/lib/File/Temp.pm
+++ b/lib/File/Temp.pm
@@ -1,4 +1,4 @@
-module File::Temp:ver<0.02>;
+unit module File::Temp:ver<0.02>;
 
 use File::Directory::Tree;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module` (unless the module is wrapped in a block).  Modules still using
the old blockless semicolon form will throw a warning.  This commit
stops the warning from appearing in the new Rakudo.